### PR TITLE
Fixed bug of unhandled POLLERR

### DIFF
--- a/src/listener.c
+++ b/src/listener.c
@@ -562,6 +562,32 @@ struct pollfd *SetupPollFds(const struct ListenerModule *lm, int *nfds) {
   return fds;
 }
 
+struct pollfd *RemovePollFd(struct pollfd *fds, int *nfds, const int fd) {
+  int i, j;
+  struct pollfd *newFds = NULL;
+
+  if ((newFds = malloc(sizeof(struct pollfd) * (*nfds - 1))) == NULL) {
+    Error("Unable to allocate memory for pollfd");
+    return NULL;
+  }
+
+  for (i = 0, j = 0; i < *nfds; i++) {
+    if (fds[i].fd == fd) {
+      continue;
+    }
+
+    newFds[j].fd = fds[i].fd;
+    newFds[j].events = fds[i].events;
+    newFds[j].revents = fds[i].revents;
+    j++;
+  }
+
+  free(fds);
+  *nfds -= 1;
+
+  return newFds;
+}
+
 struct Device *GetDeviceByFd(const struct ListenerModule *lm, const int fd) {
   for (struct Device *current = lm->root; current != NULL; current = current->next) {
     if (current->fd == fd) {

--- a/src/listener.h
+++ b/src/listener.h
@@ -19,5 +19,6 @@ uint8_t RemoveDevice(struct ListenerModule *lm, struct Device *remove);
 
 uint8_t FindDeviceByName(struct ListenerModule *lm, const char *name);
 struct pollfd *SetupPollFds(const struct ListenerModule *lm, int *nfds);
+struct pollfd *RemovePollFd(struct pollfd *fds, int *nfds, const int fd);
 struct Device *GetDeviceByFd(const struct ListenerModule *lm, const int fd);
 // void HandlePacket(u_char *args, const struct pcap_pkthdr *header, const u_char *packet);

--- a/src/sentry_pcap.c
+++ b/src/sentry_pcap.c
@@ -82,6 +82,21 @@ int PortSentryPcap(void) {
             Error("Got PCAP_ERROR_BREAK, ignoring");
           }
         } while (ret > 0);
+      } else if (fds[i].revents & POLLERR) {
+        if ((current = GetDeviceByFd(lm, fds[i].fd)) == NULL) {
+          Error("Unable to find device by fd %d", fds[i].fd);
+          goto exit;
+        }
+
+        Error("Got POLLERR on %s (fd: %d), removing interface from sentry", current->name, fds[i].fd);
+        if (RemoveDevice(lm, current) == FALSE) {
+          Error("Unable to remove device %s from sentry", current->name);
+          goto exit;
+        }
+        if ((fds = RemovePollFd(fds, &nfds, fds[i].fd)) == NULL) {
+          Error("Unable to remove fd %d from pollfd", fds[i].fd);
+          goto exit;
+        }
       }
     }
   }


### PR DESCRIPTION
Fixed bug where portsentry would go into an infinate loop state when a POLLERR occured. Bug occured when an interface was taken down. Fix removes the offending interface. This should be handled better, such as putting interface back in sentry mode when it comes back up