### PR TITLE
Docker parity with 2.0

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
-FROM debian:stable
-WORKDIR /usr/local/psionic/portsentry
+FROM debian:stable-slim
+WORKDIR /usr/local/sbin
 
 RUN apt update
 RUN apt upgrade -y
@@ -8,17 +8,17 @@ RUN apt install -y rsyslog
 COPY docker/syslogportsentry.conf /etc/rsyslog.d/
 COPY docker/rsyslog.conf /etc/rsyslog.conf
 
-RUN mkdir -p /usr/local/psionic/portsentry
+RUN mkdir -p /etc/portsentry
 RUN mkdir -p /var/run/portsentry
 
-COPY docker/entrypoint.sh /usr/local/psionic/portsentry/entrypoint.sh
-COPY portsentry /usr/local/psionic/portsentry/
-COPY portsentry.conf /usr/local/psionic/portsentry/
-COPY portsentry.ignore /usr/local/psionic/portsentry/
-RUN chmod 700 /usr/local/psionic/portsentry/entrypoint.sh
-RUN chmod 600 /usr/local/psionic/portsentry/portsentry.ignore
-RUN chmod 600 /usr/local/psionic/portsentry/portsentry.conf
-RUN chmod 700 /usr/local/psionic/portsentry/portsentry
+COPY docker/entrypoint.sh /usr/local/sbin/
+COPY portsentry /usr/local/sbin/
+COPY portsentry.conf /etc/portsentry/
+COPY portsentry.ignore /etc/portsentry/
+RUN chmod 700 /usr/local/sbin/entrypoint.sh
+RUN chmod 700 /usr/local/sbin/portsentry
+RUN chmod 600 /etc/portsentry/portsentry.ignore
+RUN chmod 600 /etc/portsentry/portsentry.conf
 
 ENTRYPOINT [ "./entrypoint.sh" ]
 CMD [ "./portsentry", "-stcp" ]

--- a/portsentry.conf
+++ b/portsentry.conf
@@ -80,7 +80,7 @@ ADVANCED_EXCLUDE_UDP="520,138,137,67"
 ######################
 #
 # Hosts to ignore
-IGNORE_FILE="/usr/local/psionic/portsentry/portsentry.ignore"
+IGNORE_FILE="/etc/portsentry/portsentry.ignore"
 # Hosts that have been denied (running history)
 HISTORY_FILE="/var/run/portsentry/portsentry.history"
 # Hosts that have been denied this session only (temporary until next restart)

--- a/portsentry_config.h
+++ b/portsentry_config.h
@@ -22,7 +22,7 @@
 
 /* These are probably ok. Be sure you change the Makefile if you */
 /* change the path */
-#define CONFIG_FILE "/usr/local/psionic/portsentry/portsentry.conf"
+#define CONFIG_FILE "/etc/portsentry/portsentry.conf"
 
 /* The location of Wietse Venema's TCP Wrapper hosts.deny file */
 #define WRAPPER_HOSTS_DENY "/etc/hosts.deny"


### PR DESCRIPTION
Changed paths in order to be in line with future v2.0 docker deployment. I.e, v1.2 and v2.0 shouldn't have any inconsistencies in deployment